### PR TITLE
Updates for Python 3.13 and more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WeechatBot
 This is an IRC bot implementation built with Weechat Python scripting.<br/>
 (c) 2020 GPLv2+ - There may be dragons.
 
-You may need some or all of these Ubuntu packages: weechat python3-psycopg2 python3-pycurl python3-iso3166
+You may need some or all of these Ubuntu packages: weechat python3-psycopg2cffi python3-pycurl python3-iso3166
 
 Disclaimer: i have no idea what i'm doing. This could be implemented much more betterer.
 

--- a/scripts/gb2wcb.py
+++ b/scripts/gb2wcb.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-import psycopg2
+import psycopg2cffi
 import pymysql.cursors
 
 dbi_h = 'gozerbot.db.source.host.tld'
@@ -16,7 +16,7 @@ dbo_d = 'weechatbotdb'
 dbi = pymysql.connect(host=dbi_h, user=dbi_u, password=dbi_p, db=dbi_d, charset='utf8mb4', cursorclass=pymysql.cursors.DictCursor)
 dbi_cur = dbi.cursor()
 
-dbo = psycopg2.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
+dbo = psycopg2cffi.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
 dbo_cur = dbo.cursor()
 
 defchannel = '#bit.nl'

--- a/scripts/ib2wcb.py
+++ b/scripts/ib2wcb.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-import psycopg2
+import psycopg2cffi
 import pymysql.cursors
 
 dbi_h = 'irssibot.db.source.host.tld'
@@ -16,7 +16,7 @@ dbo_d = 'weechatbotdb'
 dbi = pymysql.connect(host=dbi_h, user=dbi_u, password=dbi_p, db=dbi_d, charset='utf8mb4', cursorclass=pymysql.cursors.DictCursor)
 dbi_cur = dbi.cursor()
 
-dbo = psycopg2.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
+dbo = psycopg2cffi.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
 dbo_cur = dbo.cursor()
 
 defchannel = '#bit.nl'

--- a/scripts/sqlite2wcb.py
+++ b/scripts/sqlite2wcb.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-import psycopg2
+import psycopg2cffi
 import pymysql.cursors
 import sqlite3
 
@@ -15,7 +15,7 @@ dbi = sqlite3.connect(dbi_f)
 dbi.row_factory = sqlite3.Row
 dbi_cur = dbi.cursor()
 
-dbo = psycopg2.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
+dbo = psycopg2cffi.connect(host=dbo_h, user=dbo_u, password=dbo_p, dbname=dbo_d)
 dbo_cur = dbo.cursor()
 
 defchannel = '#bit.nl'

--- a/wcb_bot/__init__.py
+++ b/wcb_bot/__init__.py
@@ -387,8 +387,7 @@ class WeeChatBot:
 
 
     def wcb_handle_timer_signal(self, data, remaining_calls):
-        if 'output' not in self:
-            self.output = []
+        self.output = []
         self.event = {
             'data': data,
             'remaining_calls': remaining_calls,
@@ -443,8 +442,7 @@ class WeeChatBot:
 
 
     def wcb_handle_hook_process_callback(self, callback_data, process, process_rc, process_stdout, process_stderr):
-        if 'output' not in self:
-            self.output = []
+        self.output = []
         # Construct an event dict, assuming keys are copied from callback_data
         self.event = {
             'process': process,

--- a/wcb_bot/modules/alarm.py
+++ b/wcb_bot/modules/alarm.py
@@ -144,7 +144,7 @@ def alarm_timer_event(wcb, event):
             new_alarms.append(alarm_dict)
             continue
 
-        res = re.match('^([^\.]+)\.(.*)', alarm_dict['alarm_where'])
+        res = re.match(r'^([^\.]+)\.(.*)', alarm_dict['alarm_where'])
         if not res:
             wcb.mlog("Alarm: where '%s' did not match regexp." % alarm_dict['alarm_where'])
             continue

--- a/wcb_bot/modules/birthday.py
+++ b/wcb_bot/modules/birthday.py
@@ -26,7 +26,7 @@ def bd_set(wcb, event):
     dob = "%d-%d-%d" % (int(yy), int(mm), int(dd))
 
     db = wcb.db_connect()
-    cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
+    cur = db.cursor(cursor_factory = psycopg2cffi.extras.DictCursor)
     sql = "UPDATE wcb_users SET dob = %s WHERE id = %s"
     cur.execute(sql, (dob, event['user_info']['id']))
     db.commit()
@@ -71,7 +71,7 @@ def show_age(wcb, event):
                 EXTRACT(DAY FROM AGE(dob)) AS day
             FROM wcb_users WHERE id = %s"""
     db = wcb.db_connect()
-    cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
+    cur = db.cursor(cursor_factory = psycopg2cffi.extras.DictCursor)
     cur.execute(sql, (lookup_uid,))
     res = cur.fetchone()
     if not res:
@@ -91,7 +91,7 @@ def show_birthdays(wcb, event):
     dtt = dt.timetuple()
     nowmonth, nowday = (dtt[1], dtt[2])
     db = wcb.db_connect()
-    cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
+    cur = db.cursor(cursor_factory = psycopg2cffi.extras.DictCursor)
 
     # BDs today!
     sql = """SELECT username, dob

--- a/wcb_bot/modules/birthday.py
+++ b/wcb_bot/modules/birthday.py
@@ -1,5 +1,5 @@
 import datetime
-import psycopg2.extras
+import psycopg2cffi.extras
 import re
 
 
@@ -14,7 +14,7 @@ def config(wcb):
 
 def bd_set(wcb, event):
     args = event['command_args']
-    re_ddmmyyyy = re.compile("^(\d{1,2})-(\d{1,2})-(\d{4})$")
+    re_ddmmyyyy = re.compile(r"^(\d{1,2})-(\d{1,2})-(\d{4})$")
     res = re.match(re_ddmmyyyy, args)
     if not res:
         return wcb.reply("usage 'bd-set dd-mm-yyyy'")

--- a/wcb_bot/modules/chan-perm.py
+++ b/wcb_bot/modules/chan-perm.py
@@ -9,7 +9,7 @@ def config(wcb):
 
 def run(wcb, event):
     args_txt = event['command_args']
-    args_txt = wcb.re.sub('\s{2,}', ' ', args_txt)
+    args_txt = wcb.re.sub(r'\s{2,}', ' ', args_txt)
     args_arr = args_txt.split(' ')
 
     mode = 'list'
@@ -18,7 +18,7 @@ def run(wcb, event):
 
     channel = wcb.event['channel']
     if len(args_arr) > 1:
-        if wcb.re.match('^[#&]', args_arr[-1]):
+        if wcb.re.match(r'^[#&]', args_arr[-1]):
             channel = args_arr.pop(-1)
 
     # args_arr should now only hold permissions to set
@@ -29,14 +29,14 @@ def run(wcb, event):
     if channel not in wcb.state['chan-perm']:
         wcb.state['chan-perm'][channel] = []
 
-    if wcb.re.match('(?:list|show)', mode):
+    if wcb.re.match(r'(?:list|show)', mode):
         counter = len(wcb.state['chan-perm'][channel])
         if not counter:
             return wcb.say("No global permissions on '%s'" % channel)
         return wcb.say("There's %s global permissions on '%s': %s" %
             (counter, channel, sorted(wcb.state['chan-perm'][channel])))
 
-    if wcb.re.match('(?:set|add)', mode):
+    if wcb.re.match(r'(?:set|add)', mode):
         counter = 0
         for permission in args_arr:
             if permission in wcb.state['chan-perm'][channel]:
@@ -47,7 +47,7 @@ def run(wcb, event):
         wcb.save_obj_as_json(wcb.state, wcb.state['bot_config'])
         return wcb.say("Added %d global permissions to '%s'" % (counter, channel))
 
-    elif wcb.re.match('(?:rem(?:ove)?|del(?:ete)?)', mode):
+    elif wcb.re.match(r'(?:rem(?:ove)?|del(?:ete)?)', mode):
         counter = 0
         for permission in args_arr:
             if permission in wcb.state['chan-perm'][channel]:

--- a/wcb_bot/modules/infoitem.py
+++ b/wcb_bot/modules/infoitem.py
@@ -38,7 +38,7 @@ def do_forget(wcb, event):
         wcb.reply("you can't do that. Sorry.")
         return wcb.signal_stop
         
-    re = wcb.re.compile('([^\s]+)\s(.*)')
+    re = wcb.re.compile(r'([^\s]+)\s(.*)')
     res = re.match(event['command_args'])
     if not res:
         wcb.reply("command unclear. Try '!forget <key> <[partof]value>'. Will remove all matching entries.")
@@ -62,7 +62,7 @@ def do_forget(wcb, event):
 
 
 def do_define(wcb, event):
-    re = wcb.re.compile(wcb.state['bot_trigger_re'] + '(?:define\s)?(.+?) = (.*)')
+    re = wcb.re.compile(wcb.state['bot_trigger_re'] + r'(?:define\s)?(.+?) = (.*)')
     res = re.match(event['text'])
     pub_k = res.group(1)
     db_k = res.group(1).lower().strip()
@@ -91,13 +91,13 @@ def run(wcb, event):
     txt = event['text']
 
     # See if it is an attempt to define a thing?
-    re = wcb.re.compile(wcb.state['bot_trigger_re'] + '(?:define\s)?(.+?) = (.*)')
+    re = wcb.re.compile(wcb.state['bot_trigger_re'] + r'(?:define\s)?(.+?) = (.*)')
     res = re.match(txt)
     if res:
         return do_define(wcb, event)
 
     # See if it is an attempt to get the definition of a thing?
-    re = wcb.re.compile(wcb.state['bot_trigger_re'] + '(.+?)\?\s*$')
+    re = wcb.re.compile(wcb.state['bot_trigger_re'] + r'(.+?)\?\s*$')
     res = re.match(txt)
     if res:
         pub_k = res.group(1)

--- a/wcb_bot/modules/karma.py
+++ b/wcb_bot/modules/karma.py
@@ -1,4 +1,4 @@
-import psycopg2.extras
+import psycopg2cffi.extras
 
 
 def config(wcb):
@@ -26,7 +26,7 @@ def run(wcb, event):
 
     # Lay-zee way to prevent karma from gobbling up infoitem foo
     # This means you can't "!bla = bla++" things, but hey...
-    re = wcb.state['bot_trigger_re'] + '.+?\s=\s'
+    re = wcb.state['bot_trigger_re'] + r'.+?\s=\s'
     if wcb.re.match(re, event['text']):
         return wcb.signal_cont
 
@@ -38,7 +38,7 @@ def run(wcb, event):
     cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
 
     # Check for a karma up / down event (eg, !foo++)
-    res = wcb.re.match("^\s*(.+?)\s*(\+\+|\-\-)(?:\s*#\s*(.*))?", event_text)
+    res = wcb.re.match(r"^\s*(.+?)\s*(\+\+|\-\-)(?:\s*#\s*(.*))?", event_text)
     if res:
         item = res.group(1).lower()
         direction = res.group(2)
@@ -111,7 +111,7 @@ def run(wcb, event):
             return wcb.reply("karma for '%s' is neutral" % item)
 
 
-    res = wcb.re.match("^(?:karma-why|why-karma|why)\-?(up|down)", event['command'])
+    res = wcb.re.match(r"^(?:karma-why|why-karma|why)\-?(up|down)", event['command'])
     if res:
         direction = res.group(1)
         item = event['command_args'].lower()
@@ -143,7 +143,7 @@ def run(wcb, event):
         else:
             return wcb.reply("no reasons were given for karma %s" % direction)
     
-    res = wcb.re.match("^(?:karma-who|who-karma|who)\-?(up|down)", event['command'])
+    res = wcb.re.match(r"^(?:karma-who|who-karma|who)\-?(up|down)", event['command'])
     if res:
         direction = res.group(1)
         item = event['command_args'].lower()
@@ -179,7 +179,7 @@ def run(wcb, event):
         return wcb.reply("the following person(s) brought the karma %s: %s" % (direction, rtxt))
 
 
-    res = wcb.re.match("^(good|bad)ness", event['command'])
+    res = wcb.re.match(r"^(good|bad)ness", event['command'])
     if res:
         direction = res.group(1)
         sql_direction = "ASC"
@@ -204,7 +204,7 @@ def run(wcb, event):
         return wcb.say(rtxt)
 
 
-    res = wcb.re.match("^(lovers|fans|haters)", event['command'])
+    res = wcb.re.match(r"^(lovers|fans|haters)", event['command'])
     if res:
         direction = res.group(1)
         item = event['command_args'].lower()
@@ -241,7 +241,7 @@ def run(wcb, event):
         return wcb.reply(rtxt)
 
 
-    res = wcb.re.match("^set\-?karma\s+(.+?)\s+([-0-9]+)", event_text)
+    res = wcb.re.match(r"^set\-?karma\s+(.+?)\s+([-0-9]+)", event_text)
     if res:
         if not wcb.perms(["owner", "set-karma"]): return wcb.reply("i can't let you do that.")
         item = res.group(1).lower()
@@ -253,7 +253,7 @@ def run(wcb, event):
         return wcb.reply("ok.")
 
 
-    res = wcb.re.match("^(?:karma-del|del-karma)\s+(.*)", event['command'])
+    res = wcb.re.match(r"^(?:karma-del|del-karma)\s+(.*)", event['command'])
     if res:
         if not wcb.perms(["owner", "set-karma"]): return wcb.reply("i can't let you do that.")
         item = res.group(1).lower()
@@ -268,7 +268,7 @@ def run(wcb, event):
         return wcb.reply("ok.")
 
 
-    res = wcb.re.match("^karma-search", event['command'])
+    res = wcb.re.match(r"^karma-search", event['command'])
     if res:
         item = event['command_args'].lower()
         if item == '': return wcb.reply('please specify a term to search for.')

--- a/wcb_bot/modules/karma.py
+++ b/wcb_bot/modules/karma.py
@@ -35,7 +35,7 @@ def run(wcb, event):
 
     # We gonna need some DB yo.
     db = wcb.db_connect()
-    cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
+    cur = db.cursor(cursor_factory = psycopg2cffi.extras.DictCursor)
 
     # Check for a karma up / down event (eg, !foo++)
     res = wcb.re.match(r"^\s*(.+?)\s*(\+\+|\-\-)(?:\s*#\s*(.*))?", event_text)

--- a/wcb_bot/modules/mass-perm.py
+++ b/wcb_bot/modules/mass-perm.py
@@ -9,7 +9,7 @@ def config(wcb):
 
 def run(wcb, event):
     args_txt = event['command_args']
-    args_txt = wcb.re.sub('\s{2,}', ' ', args_txt)
+    args_txt = wcb.re.sub(r'\s{2,}', ' ', args_txt)
     args_arr = args_txt.split(' ')
 
     if len(args_arr) < 2:

--- a/wcb_bot/modules/oui.py
+++ b/wcb_bot/modules/oui.py
@@ -108,7 +108,7 @@ def actualOUILookup(wcb, mac_input):
 def OUILookup(wcb, mac_input):
     mac_input = mac_input.upper()
     mac_input = mac_input.replace('-', ':')
-    mac_input = re.sub('[^A-F0-9:]', '', mac_input)
+    mac_input = re.sub(r'[^A-F0-9:]', '', mac_input)
 
     octets = mac_input.split(':')
 

--- a/wcb_bot/modules/perm.py
+++ b/wcb_bot/modules/perm.py
@@ -9,7 +9,7 @@ def config(wcb):
 
 def run(wcb, event):
     args_txt = event['command_args']
-    args_txt = wcb.re.sub('\s{2,}', ' ', args_txt)
+    args_txt = wcb.re.sub(r'\s{2,}', ' ', args_txt)
     args_arr = args_txt.split(' ')
 
     if len(args_arr) < 3:
@@ -18,7 +18,7 @@ def run(wcb, event):
     mode = args_arr.pop(0)
     nick = args_arr.pop(0)
     channel = ''
-    if wcb.re.match('^[#&]', args_arr[-1]):
+    if wcb.re.match(r'^[#&]', args_arr[-1]):
         channel = args_arr.pop(-1)
 
     # args_arr should now only hold permissions to set
@@ -30,7 +30,7 @@ def run(wcb, event):
     db = wcb.db_connect()
     cur = db.cursor()
 
-    if wcb.re.match('(?:set|add)', mode):
+    if wcb.re.match(r'(?:set|add)', mode):
         counter = 0
         sql = "INSERT INTO wcb_perms (users_id, permission, channel) VALUES (%s, %s, %s)"
         for permission in args_arr:
@@ -39,7 +39,7 @@ def run(wcb, event):
         db.commit(); cur.close(); db.close()
         return wcb.say("Added %d permissions to '%s'" % (counter, nick))
 
-    elif wcb.re.match('(?:rem(?:ove)?|del(?:ete)?)', mode):
+    elif wcb.re.match(r'(?:rem(?:ove)?|del(?:ete)?)', mode):
         counter = 0
         sql = "DELETE FROM wcb_perms WHERE users_id = %s AND permission = %s AND channel = %s"
         for permission in args_arr:

--- a/wcb_bot/modules/quotes.py
+++ b/wcb_bot/modules/quotes.py
@@ -21,7 +21,7 @@ def config(wcb):
 def run(wcb, event):
 
     db = wcb.db_connect()
-    cur = db.cursor(cursor_factory = psycopg2.extras.DictCursor)
+    cur = db.cursor(cursor_factory = psycopg2cffi.extras.DictCursor)
 
     if event['command'] == 'aq':
         quote = event['command_args']

--- a/wcb_bot/modules/quotes.py
+++ b/wcb_bot/modules/quotes.py
@@ -1,4 +1,4 @@
-import psycopg2.extras
+import psycopg2cffi.extras
 import random
 
 
@@ -90,7 +90,7 @@ def run(wcb, event):
         return
 
 
-    res = wcb.re.match('^(?:q|quote|rq|rq3|r3q)$', event['command'])
+    res = wcb.re.match(r'^(?:q|quote|rq|rq3|r3q)$', event['command'])
     if res:
         count = 1
         if '3' in event['command']:
@@ -120,7 +120,7 @@ def run(wcb, event):
         return
     
 
-    res = wcb.re.match('^(?:lq|l3q|lq3)$', event['command'])
+    res = wcb.re.match(r'^(?:lq|l3q|lq3)$', event['command'])
     if res:
         count = 1
         if '3' in event['command']:
@@ -145,7 +145,7 @@ def run(wcb, event):
         return
 
 
-    res = wcb.re.match('^quote-(?:who|when)$', event['command'])
+    res = wcb.re.match(r'^quote-(?:who|when)$', event['command'])
     if res:
         quote_id = event['command_args']
         if not quote_id.isnumeric():

--- a/wcb_bot/modules/reoplist.py
+++ b/wcb_bot/modules/reoplist.py
@@ -84,7 +84,7 @@ def run(wcb, event):
 
     tag = event['server'] + '.' + event['channel']
     bot_plus_r_nickmask = event['bot_nick'] + '*!*' + event['bot_hostmask']
-    bot_plus_r_nickmask = re.sub('!.*@', '!*@', bot_plus_r_nickmask)
+    bot_plus_r_nickmask = re.sub(r'!.*@', '!*@', bot_plus_r_nickmask)
 
     if event['signal'] == 'irc_in2_344':
         reoplist_item_event(wcb, event, tag, bot_plus_r_nickmask)

--- a/wcb_bot/modules/state.py
+++ b/wcb_bot/modules/state.py
@@ -16,7 +16,7 @@ def run(wcb, event):
         return wcb.say("Bot configuration saved!")
 
     if event['command'] == 'set-json':
-        res = wcb.re.match("^([^\s]+)[\s=]+(.*)", event['command_args'])
+        res = wcb.re.match(r"^([^\s]+)[\s=]+(.*)", event['command_args'])
         if not res:
             return wcb.say("Could not discern key, value from arguments: '%s'" % event['command_args'])
 
@@ -35,7 +35,7 @@ def run(wcb, event):
         return wcb.save_obj_as_json(wcb.state, wcb.state['bot_config'])
 
     if event['command'] == 'set':
-        res = wcb.re.match("^([^\s]+)[\s=]+(.*)", event['command_args'])
+        res = wcb.re.match(r"^([^\s]+)[\s=]+(.*)", event['command_args'])
         if not res:
             return wcb.say("Could not discern key, value from arguments: '%s'" % event['command_args'])
 

--- a/wcb_bot/modules/topic.py
+++ b/wcb_bot/modules/topic.py
@@ -29,7 +29,7 @@ def run(wcb, event):
         return wcb.signal_cont
 
 
-    if wcb.re.match("^(?:pt|previous-topic)$", event['command']):
+    if wcb.re.match(r"^(?:pt|previous-topic)$", event['command']):
         if event['channel'] not in wcb.state['previous_topic']:
             return wcb.say("No topic information on '%s' was saved yet." % event['channel'])
         return wcb.say("Previous topic on '%s' was '%s'" % (event['channel'], wcb.state['previous_topic'][event['channel']]))

--- a/wcb_bot/modules/urls.py
+++ b/wcb_bot/modules/urls.py
@@ -29,7 +29,7 @@ def run(wcb, event):
     manual_urls_trigger = False
 
     # See if url can be matched.
-    res = wcb.re.search("(?i)(https?\:\/\/[a-z0-9\-\_]+\.[a-z0-9\-\.\_]+(?:\/[^\s]+)*[^\s])", event['text'])
+    res = wcb.re.search(r"(?i)(https?\:\/\/[a-z0-9\-\_]+\.[a-z0-9\-\.\_]+(?:\/[^\s]+)*[^\s])", event['text'])
     if res:
         url = res.group(1)
         if '..' in url:
@@ -91,7 +91,7 @@ def __pycurl_headerfn(header_line):
 
 
 def fetchURLinfo(wcb, url):
-    if not wcb.re.match("^https?://", url):
+    if not wcb.re.match(r"^https?://", url):
         url = 'https://' + url
 
     req_headers = [
@@ -117,7 +117,7 @@ def fetchURLinfo(wcb, url):
     encoding = None
     if 'content-type' in headers:
         content_type = headers['content-type'].lower()
-        res = wcb.re.search('charset=(\S+)', content_type)
+        res = wcb.re.search(r'charset=(\S+)', content_type)
         if res:
             encoding = res.group(1)
     if encoding is None:
@@ -126,7 +126,7 @@ def fetchURLinfo(wcb, url):
         return {'title': 'binary data', 'encoding': encoding, 'content-type': content_type}
 
     if content_type:
-        content_type = wcb.re.sub(';.*', '', content_type)
+        content_type = wcb.re.sub(r';.*', '', content_type)
     else:
         content_type = 'undef'
 
@@ -146,10 +146,10 @@ def fetchURLinfo(wcb, url):
         return {'title': '', 'encoding': '', 'content-type': ''}
 
     title = '[title tag not found]'
-    res = wcb.re.search('(?ims)<title[^>]*>(.+?)<\/title', body)
+    res = wcb.re.search(r'(?ims)<title[^>]*>(.+?)<\/title', body)
     if res:
         title = html.unescape(res.group(1))
-        title = wcb.re.sub('^\\s+', ' ', title, flags=wcb.re.MULTILINE).strip()
-        title = wcb.re.sub('[\r\n]', '', title, flags=wcb.re.MULTILINE).strip()
+        title = wcb.re.sub(r'^\\s+', ' ', title, flags=wcb.re.MULTILINE).strip()
+        title = wcb.re.sub(r'[\r\n]', '', title, flags=wcb.re.MULTILINE).strip()
 
     return {'title': title, 'encoding': encoding, 'content-type': content_type}

--- a/wcb_bot/modules/wolfram.py
+++ b/wcb_bot/modules/wolfram.py
@@ -90,7 +90,7 @@ def fetchURL(wcb, url):
     encoding = None
     if 'content-type' in headers:
         content_type = headers['content-type'].lower()
-        res = wcb.re.search('charset=(\S+)', content_type)
+        res = wcb.re.search(r'charset=(\S+)', content_type)
         if res:
             encoding = res.group(1)
     if encoding is None:


### PR DESCRIPTION
Switch to using `python3-psycopg2cffi`. This makes psycopg2 work inside new Weechat with new Python where in more recent installs it would croak about not being able to import some Encodings thing.  `ImportError: cannot import name 'encodings' from 'psycopg2._psycopg'`

Change all regexps to be defined as `r''` fixing 'invalid escape sequence...'-messages from recent Python.

Better deal with `ignore_max_output_*`-toggles, that could be set from a module in the event data. It was broken and is now fixed i hope.

'Defang' text passed to `weechat.command()` in the event it might start with a WeeChat slash-command like `/msg`, `/part` or `/quit`...

